### PR TITLE
Fix: render the concept text when editing it

### DIFF
--- a/LinkedIdeas-Shared/Sources/Models/Concept.swift
+++ b/LinkedIdeas-Shared/Sources/Models/Concept.swift
@@ -123,7 +123,9 @@ public class Concept: NSObject, NSCoding, Element {
   // MARK: - Methods
 
   public func draw() {
-    attributedStringValue.draw(in: textArea)
+    if !isEditable {
+      attributedStringValue.draw(in: textArea)
+    }
   }
 
   public func contains(point: CGPoint) -> Bool {

--- a/LinkedIdeas-Shared/Sources/ViewModels/DrawableConcept.swift
+++ b/LinkedIdeas-Shared/Sources/ViewModels/DrawableConcept.swift
@@ -41,13 +41,6 @@ public struct DrawableConcept: DrawableElement {
     drawingBounds.fill()
   }
 
-  func drawConceptText() {
-    if !concept.isEditable {
-      Color.black.set()
-      concept.attributedStringValue.draw(in: drawingBounds)
-    }
-  }
-
   func drawSelectedRing() {
     guard concept.isSelected else {
       return

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+StateManagerDelegate.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+StateManagerDelegate.swift
@@ -88,6 +88,8 @@ extension CanvasViewController: StateManagerDelegate {
       return
     }
 
+    element.isEditable = true
+
     if let concept = element as? Concept {
       showTextView(
         inRect: element.area,


### PR DESCRIPTION
So you see the previous value of the concept under the editing text field.

Changes:

- Set element as being editing when transition to the editing state

- Only render concept if it's not being edited

- Remove unused `drawConceptText()`
  Now this is handled at `Concept` level

Fixes https://github.com/fespinoza/LinkedIdeas/issues/81