### PR TITLE
Ensure both colors are in the RGB colorspace

### DIFF
--- a/LinkedIdeas-Shared/Sources/Colors/Color.swift
+++ b/LinkedIdeas-Shared/Sources/Colors/Color.swift
@@ -38,14 +38,15 @@ extension Color {
     #if os(iOS)
       return true
     #else
-    guard let otherColor = otherColor.usingColorSpace(self.colorSpace) else {
+    guard let otherColor = otherColor.usingColorSpace(.deviceRGB),
+        let rgbColor = self.usingColorSpace(.deviceRGB) else {
       return false
     }
 
-    return floor(self.redComponent * 255) == floor(otherColor.redComponent * 255) &&
-      floor(self.greenComponent * 255) == floor(otherColor.greenComponent * 255) &&
-      floor(self.blueComponent * 255) == floor(otherColor.blueComponent * 255) &&
-      floor(self.alphaComponent * 255) == floor(otherColor.alphaComponent * 255)
+    return floor(rgbColor.redComponent * 255) == floor(otherColor.redComponent * 255) &&
+      floor(rgbColor.greenComponent * 255) == floor(otherColor.greenComponent * 255) &&
+      floor(rgbColor.blueComponent * 255) == floor(otherColor.blueComponent * 255) &&
+      floor(rgbColor.alphaComponent * 255) == floor(otherColor.alphaComponent * 255)
     #endif
   }
 }


### PR DESCRIPTION
in order to compare their components, otherwise this will crash, fixes #121 