### PR TITLE
Add support for option+drag to duplicate a concept

### DIFF
--- a/LinkedIdeas-Shared/Sources/Models/Concept.swift
+++ b/LinkedIdeas-Shared/Sources/Models/Concept.swift
@@ -178,6 +178,14 @@ public class Concept: NSObject, NSCoding, Element {
     mode = .modifiedWidth(width: newWidth)
   }
 
+  public func duplicate() -> Concept {
+    let attributedCopy = (attributedStringValue.copy() as? NSAttributedString)
+      ?? NSAttributedString(string: stringValue)
+    let concept = Concept(attributedStringValue: attributedCopy, centerPoint: centerPoint)
+    concept.mode = mode
+    return concept
+  }
+
   // MARK: - NSCoding
 
   required public init?(coder aDecoder: NSCoder) {

--- a/LinkedIdeas/UI/CanvasViewController.swift
+++ b/LinkedIdeas/UI/CanvasViewController.swift
@@ -18,6 +18,7 @@ class CanvasViewController: NSViewController {
 
   var dragCount = 0
   var didShiftDragStart = false
+  var didOptionDragStart = false
   // to register the beginning of the drag
   // for undo purposes
   var dragStartPoint: CGPoint?
@@ -181,7 +182,15 @@ class CanvasViewController: NSViewController {
   }
 
   func isPressingShift(event: NSEvent) -> Bool {
-    return event.modifierFlags.contains(NSEvent.ModifierFlags.shift)
+    return event.modifierFlags.contains(.shift)
+  }
+
+  func isDragOptionEvent(_ event: NSEvent) -> Bool {
+    return isPressingOption(event: event) // || didShiftDragStart
+  }
+
+  func isPressingOption(event: NSEvent) -> Bool {
+    return event.modifierFlags.contains(.option)
   }
 
   // MARK: - current State data helpers

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+DraggingActions.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+DraggingActions.swift
@@ -117,6 +117,7 @@ extension CanvasViewController {
   // MARK: General drag operations
   func resetDraggingConcepts() {
     didShiftDragStart = false
+    didOptionDragStart = false
     dragStartPoint = nil
     dragCount = 0
     canvasView.selectFromPoint = nil

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+MouseEvents.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+MouseEvents.swift
@@ -131,6 +131,15 @@ extension CanvasViewController {
             unselect(elements: document.concepts.filter { $0 != concept })
           }
         }
+      } else if isDragOptionEvent(event) {
+        if didOptionDragStart {
+          drag(concept: concept, toPoint: point)
+        } else {
+          didOptionDragStart = true
+          safeTransiton {
+            try stateManager.toSelectedElementDuplicating(concept: concept)
+          }
+        }
       } else {
         drag(concept: concept, toPoint: point)
       }
@@ -171,6 +180,8 @@ extension CanvasViewController {
           whenClickedOnSingleConcept(atPoint: point, thenDo: { (targetConcept) in
             createNewLinkUp(fromConcept: concept, toConcept: targetConcept)
           })
+        } else if isDragOptionEvent(event) {
+          endDrag(forConcept: concept, toPoint: point)
         } else {
           endDrag(forConcept: concept, toPoint: point)
         }

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+StateManagerDelegate.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+StateManagerDelegate.swift
@@ -81,6 +81,21 @@ extension CanvasViewController: StateManagerDelegate {
     transitionedToSelectedElement(fromState: fromState)
   }
 
+  func transitionedToSelectedElementDuplicatingConcept(fromState: CanvasState) {
+    commonTransitionBehavior(fromState)
+
+    guard
+      case .selectedElement(let element) = currentState,
+      let concept = element as? Concept
+    else {
+      return
+    }
+
+    document.save(concept: concept)
+
+    select(elements: [concept])
+  }
+
   func transitionedToEditingElement(fromState: CanvasState) {
     commonTransitionBehavior(fromState)
 

--- a/LinkedIdeas/UI/StateManager.swift
+++ b/LinkedIdeas/UI/StateManager.swift
@@ -22,6 +22,7 @@ protocol StateManagerDelegate: class {
   func transitionedToCanvasWaitingDeletingElements(fromState: CanvasState)
   func transitionedToSelectedElement(fromState: CanvasState)
   func transitionedToSelectedElementSavingChanges(fromState: CanvasState)
+  func transitionedToSelectedElementDuplicatingConcept(fromState: CanvasState)
   func transitionedToEditingElement(fromState: CanvasState)
   func transitionedToMultipleSelectedElements(fromState: CanvasState)
   func transitionedToResizingConcept(fromState: CanvasState)
@@ -186,6 +187,22 @@ class StateManager {
     let state = CanvasState.selectedElement(element: element)
     try transition(toState: state, withValidtransitions: isValidTransition) { (oldState) in
       delegate?.transitionedToSelectedElementSavingChanges(fromState: oldState)
+    }
+  }
+
+  public func toSelectedElementDuplicating(concept: Concept) throws {
+    func isValidTransition(fromState: CanvasState) -> Bool {
+      switch fromState {
+      case .selectedElement(let element):
+        return element is Concept
+      default:
+        return false
+      }
+    }
+
+    let state = CanvasState.selectedElement(element: concept.duplicate())
+    try transition(toState: state, withValidtransitions: isValidTransition) { (oldState) in
+      delegate?.transitionedToSelectedElementDuplicatingConcept(fromState: oldState)
     }
   }
 

--- a/LinkedIdeasTests/TestProtocolConformance.swift
+++ b/LinkedIdeasTests/TestProtocolConformance.swift
@@ -45,6 +45,10 @@ class StateManagerTestDelegate: MockMethodCalls {
 }
 
 extension StateManagerTestDelegate: StateManagerDelegate {
+  func transitionedToSelectedElementDuplicatingConcept(fromState: CanvasState) {
+    registerCall(methodName: #function)
+  }
+
   func transitionedToResizingConcept(fromState: CanvasState) {
     registerCall(methodName: #function)
   }


### PR DESCRIPTION
To quickly duplicate elements, like you see on Keynote or Sketch