### PR TITLE
Feature: multiple option drag for duplicating concepts

### DIFF
--- a/LinkedIdeas/Models/Document.swift
+++ b/LinkedIdeas/Models/Document.swift
@@ -138,9 +138,9 @@ public class Document: NSDocument {
 
       switch object {
       case let concept as Concept:
-        observer?.documentChanged(withElement: concept)
+        observer?.documentChanged(with: concept)
       case let link as Link:
-        observer?.documentChanged(withElement: link)
+        observer?.documentChanged(with: link)
       default:
         break
       }
@@ -155,7 +155,7 @@ extension Document: LinkedIdeasDocument {
       withTarget: self,
       selector: #selector(Document.remove(concept:)),
       object: concept)
-    observer?.documentChanged(withElement: concept)
+    observer?.documentChanged(with: concept)
   }
 
   @objc func remove(concept: Concept) {
@@ -164,7 +164,7 @@ extension Document: LinkedIdeasDocument {
       withTarget: self,
       selector: #selector(Document.save(concept:)),
       object: concept)
-    observer?.documentChanged(withElement: concept)
+    observer?.documentChanged(with: concept)
   }
 
   @objc func save(link: Link) {
@@ -173,7 +173,7 @@ extension Document: LinkedIdeasDocument {
       withTarget: self,
       selector: #selector(Document.remove(link:)),
       object: link)
-    observer?.documentChanged(withElement: link)
+    observer?.documentChanged(with: link)
   }
 
   @objc func remove(link: Link) {
@@ -182,14 +182,14 @@ extension Document: LinkedIdeasDocument {
       withTarget: self,
       selector: #selector(Document.save(link:)),
       object: link)
-    observer?.documentChanged(withElement: link)
+    observer?.documentChanged(with: link)
   }
 
   func move(concept: Concept, toPoint: CGPoint) {
     Swift.print("move concept \(concept) toPoint: \(toPoint)")
     let originalPoint = concept.centerPoint
     concept.centerPoint = toPoint
-    observer?.documentChanged(withElement: concept)
+    observer?.documentChanged(with: concept)
 
     undoManager?.registerUndo(withTarget: self, handler: { (object) in
       object.move(concept: concept, toPoint: originalPoint)

--- a/LinkedIdeas/Models/Document.swift
+++ b/LinkedIdeas/Models/Document.swift
@@ -157,6 +157,16 @@ extension Document: LinkedIdeasDocument {
       object: concept)
     observer?.documentChanged(with: concept)
   }
+  
+  @objc func save(concepts newConcepts: [Concept]) {
+    concepts.append(contentsOf: newConcepts)
+    undoManager?.registerUndo(
+      withTarget: self,
+      selector: #selector(Document.remove(concepts:)),
+      object: newConcepts
+    )
+    observer?.documentChanged(with: newConcepts)
+  }
 
   @objc func remove(concept: Concept) {
     concepts.remove(at: concepts.firstIndex(of: concept)!)
@@ -165,6 +175,20 @@ extension Document: LinkedIdeasDocument {
       selector: #selector(Document.save(concept:)),
       object: concept)
     observer?.documentChanged(with: concept)
+  }
+  
+  @objc func remove(concepts newConcepts: [Concept]) {
+    newConcepts.forEach { concept in
+      if let index = concepts.firstIndex(of: concept) {
+        concepts.remove(at: index)
+      }
+    }
+    undoManager?.registerUndo(
+      withTarget: self,
+      selector: #selector(Document.save(concepts:)),
+      object: newConcepts
+    )
+    observer?.documentChanged(with: newConcepts)
   }
 
   @objc func save(link: Link) {

--- a/LinkedIdeas/Models/Protocols/DocumentObserver.swift
+++ b/LinkedIdeas/Models/Protocols/DocumentObserver.swift
@@ -9,5 +9,6 @@ import Foundation
 import LinkedIdeas_Shared
 
 protocol DocumentObserver {
-  func documentChanged(withElement element: Element)
+  func documentChanged(with element: Element)
+  func documentChanged(with elements: [Element])
 }

--- a/LinkedIdeas/Models/Protocols/LinkedIdeasDocument.swift
+++ b/LinkedIdeas/Models/Protocols/LinkedIdeasDocument.swift
@@ -16,7 +16,9 @@ protocol LinkedIdeasDocument {
   var observer: DocumentObserver? { get set }
 
   func save(concept: Concept)
+  func save(concepts: [Concept])
   func remove(concept: Concept)
+  func remove(concepts: [Concept])
 
   func save(link: Link)
   func remove(link: Link)

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+DocumentObserver.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+DocumentObserver.swift
@@ -12,7 +12,11 @@ import LinkedIdeas_Shared
 // MARK: - CanvasViewController+DocumentObserver
 
 extension CanvasViewController: DocumentObserver {
-  func documentChanged(withElement element: Element) {
+  func documentChanged(with element: Element) {
+    reRenderCanvasView()
+  }
+  
+  func documentChanged(with elements: [Element]) {
     reRenderCanvasView()
   }
 }

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+MouseEvents.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+MouseEvents.swift
@@ -150,7 +150,18 @@ extension CanvasViewController {
       }
 
       if !isPressingShift(event: event) {
-        drag(concepts: concepts, toPoint: point)
+        if isDragOptionEvent(event) {
+          if didOptionDragStart {
+            drag(concepts: concepts, toPoint: point)
+          } else {
+              didOptionDragStart = true
+              safeTransiton {
+                try stateManager.toMultipleSelectedElementsDuplicating(concepts: concepts)
+              }
+          }
+        } else {
+          drag(concepts: concepts, toPoint: point)
+        }
       }
 
     case .canvasWaiting:

--- a/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+StateManagerDelegate.swift
+++ b/LinkedIdeas/UI/CanvasViewControllerExtensions/CanvasViewController+StateManagerDelegate.swift
@@ -95,6 +95,19 @@ extension CanvasViewController: StateManagerDelegate {
 
     select(elements: [concept])
   }
+  
+  func transitionedToMultipleSelectedElementsDuplicatingConcepts(fromState: CanvasState) {
+    commonTransitionBehavior(fromState)
+    
+    guard case .multipleSelectedElements(let elements) = currentState else {
+        return
+    }
+    
+    let concepts = elements.compactMap({ $0 as? Concept })
+    document.save(concepts: concepts)
+    
+    select(elements: concepts)
+  }
 
   func transitionedToEditingElement(fromState: CanvasState) {
     commonTransitionBehavior(fromState)

--- a/LinkedIdeas/UI/StateManager.swift
+++ b/LinkedIdeas/UI/StateManager.swift
@@ -25,6 +25,7 @@ protocol StateManagerDelegate: class {
   func transitionedToSelectedElementDuplicatingConcept(fromState: CanvasState)
   func transitionedToEditingElement(fromState: CanvasState)
   func transitionedToMultipleSelectedElements(fromState: CanvasState)
+  func transitionedToMultipleSelectedElementsDuplicatingConcepts(fromState: CanvasState)
   func transitionedToResizingConcept(fromState: CanvasState)
 }
 
@@ -221,6 +222,24 @@ class StateManager {
     let state = CanvasState.multipleSelectedElements(elements: elements)
     try transition(toState: state, withValidtransitions: isValidTransition) { (oldState) in
       delegate?.transitionedToMultipleSelectedElements(fromState: oldState)
+    }
+  }
+  
+  public func toMultipleSelectedElementsDuplicating(concepts: [Concept]) throws {
+    func isValidTransition(fromState: CanvasState) -> Bool {
+      switch fromState {
+      case .multipleSelectedElements(let elements):
+        return elements.compactMap({ $0 as? Concept }).count > 0
+      default:
+        return false
+      }
+    }
+    
+    let duplicates = concepts.map({ $0.duplicate() })
+    let state = CanvasState.multipleSelectedElements(elements: duplicates)
+
+    try transition(toState: state, withValidtransitions: isValidTransition) { (oldState) in
+      delegate?.transitionedToMultipleSelectedElementsDuplicatingConcepts(fromState: oldState)
     }
   }
 

--- a/LinkedIdeasTests/TestProtocolConformance.swift
+++ b/LinkedIdeasTests/TestProtocolConformance.swift
@@ -18,6 +18,12 @@ class TestLinkedIdeasDocument: LinkedIdeasDocument {
   func save(concept: Concept) {
     concepts.append(concept)
   }
+  
+  func save(concepts newConcepts: [Concept]) {
+    concepts.append(contentsOf: newConcepts)
+  }
+  
+  func remove(concepts: [Concept]) {}
   func remove(concept: Concept) {}
 
   func save(link: Link) {}

--- a/LinkedIdeasTests/TestProtocolConformance.swift
+++ b/LinkedIdeasTests/TestProtocolConformance.swift
@@ -51,6 +51,10 @@ class StateManagerTestDelegate: MockMethodCalls {
 }
 
 extension StateManagerTestDelegate: StateManagerDelegate {
+  func transitionedToMultipleSelectedElementsDuplicatingConcepts(fromState: CanvasState) {
+    registerCall(methodName: #function)
+  }
+  
   func transitionedToSelectedElementDuplicatingConcept(fromState: CanvasState) {
     registerCall(methodName: #function)
   }


### PR DESCRIPTION
following what I did in #126, but now it also works with multiple concepts selected.

This doesn't duplicate links (for now)